### PR TITLE
expireDate 컬럼 추가

### DIFF
--- a/src/main/java/com/sh/point/application/service/point/PointBalanceService.java
+++ b/src/main/java/com/sh/point/application/service/point/PointBalanceService.java
@@ -1,13 +1,13 @@
 package com.sh.point.application.service.point;
 
 import java.math.BigDecimal;
-import java.time.LocalDateTime;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.sh.point.domain.point.PointDetail;
 import com.sh.point.domain.point.PointDetailRepository;
+import com.sh.point.domain.point.exception.InvalidAmountException;
 import com.sh.point.web.controller.point.dto.balance.PointBalanceResponse;
 
 import lombok.RequiredArgsConstructor;
@@ -17,21 +17,26 @@ import lombok.RequiredArgsConstructor;
 @Transactional(readOnly = true)
 public class PointBalanceService {
 	private final PointDetailRepository pointDetailRepository;
-	private final TimeProvider timeProvider;
 
 	public PointBalanceResponse getAvailableBalance(String userId) {
-		LocalDateTime oneYearAgo = timeProvider.now().minusYears(1);
-
 		PointDetail latestDetail = pointDetailRepository.findTopByUserIdOrderByIdDesc(userId)
 			.orElseGet(() -> PointDetail.createInitial(userId));
 
-		PointDetail expiredDetail = pointDetailRepository.findTopByUserIdAndProcessDateBeforeOrderByProcessDateDesc(
-				userId, oneYearAgo)
-			.orElseGet(() -> PointDetail.createInitial(userId));
+		BigDecimal expiredPointSum = pointDetailRepository.findExpiredPointSum(userId);
 
 		// 만료 금액을 제외한다. (1년전 사용 할수 있는 모든 금액은 만료되어야 하므로)
-		BigDecimal balance = latestDetail.calculateAvailableBalanceWithOutExpiredAmount()
-			.subtract(expiredDetail.getDepositSum());
+		BigDecimal balance = getBigDecimal(latestDetail, expiredPointSum);
+
 		return new PointBalanceResponse(userId, balance);
+	}
+
+	private static BigDecimal getBigDecimal(PointDetail latestDetail, BigDecimal expiredPointSum) {
+		BigDecimal balance = latestDetail.calculateAvailableBalanceWithOutExpiredAmount().subtract(expiredPointSum);
+
+		if (balance.compareTo(BigDecimal.ZERO) < 0) {
+			throw new InvalidAmountException();
+		}
+
+		return balance;
 	}
 }

--- a/src/main/java/com/sh/point/application/service/point/PointWithdrawService.java
+++ b/src/main/java/com/sh/point/application/service/point/PointWithdrawService.java
@@ -1,5 +1,6 @@
 package com.sh.point.application.service.point;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
 import org.springframework.stereotype.Service;
@@ -28,12 +29,10 @@ public class PointWithdrawService {
 			.orElseThrow(() -> new PointNotFoundException(request.userId()));
 
 		// 만료된 포인트 조회 (만료 날짜 기준 -> 현시점 1년전)
-		PointDetail expiredDetail = pointDetailRepository.findTopByUserIdAndProcessDateBeforeOrderByProcessDateDesc(
-				request.userId(), oneYearAgo)
-			.orElseGet(() -> PointDetail.createInitial(request.userId()));
+		BigDecimal expiredPointSum = pointDetailRepository.findExpiredPointSum(request.userId());
 
 		// expiredDetail.getDepositSum() : 1년전 적립금액 -> 현재는 만료 되었어야 하는 금액.
-		PointDetail usedDetail = latestDetail.withdraw(request.amount(), expiredDetail.getDepositSum(), now);
+		PointDetail usedDetail = latestDetail.withdraw(request.amount(), expiredPointSum, now);
 		pointDetailRepository.save(usedDetail);
 	}
 }

--- a/src/main/java/com/sh/point/domain/BaseEntity.java
+++ b/src/main/java/com/sh/point/domain/BaseEntity.java
@@ -9,7 +9,9 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
 
+@Getter
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
 public abstract class BaseEntity {

--- a/src/main/java/com/sh/point/domain/point/PointDetail.java
+++ b/src/main/java/com/sh/point/domain/point/PointDetail.java
@@ -43,6 +43,9 @@ public class PointDetail extends BaseEntity {
 	@Column(nullable = false)
 	private LocalDateTime processDate;
 
+	@Column(nullable = false)
+	private LocalDateTime expireDate;
+
 	// 여태까지 쌓아온 포인트의 합
 	@Column(nullable = false, precision = 19, scale = 2)
 	private BigDecimal depositSum = BigDecimal.ZERO;
@@ -55,6 +58,7 @@ public class PointDetail extends BaseEntity {
 		setUserId(userId);
 		this.amount = BigDecimal.ZERO;
 		this.processDate = LocalDateTime.now();
+		this.expireDate = processDate.plusYears(1);
 	}
 
 	public static PointDetail createInitial(String userId) {
@@ -81,6 +85,7 @@ public class PointDetail extends BaseEntity {
 			PointType.POINT_USE,
 			this.userId,
 			processDate,
+			processDate.plusYears(1),
 			this.depositSum,
 			this.withdrawSum.subtract(amount)
 		);
@@ -91,13 +96,15 @@ public class PointDetail extends BaseEntity {
 			throw new InvalidAmountException();
 		}
 		return new PointDetail(amount, PointType.POINT_ACCUMULATE, this.userId, processDate,
-			this.depositSum.add(amount), this.withdrawSum);
+			processDate.plusYears(1), this.depositSum.add(amount), this.withdrawSum);
 	}
 
 	private PointDetail(BigDecimal amount, PointType pointType, String userId, LocalDateTime processDate,
+		LocalDateTime expireDate,
 		BigDecimal depositSum, BigDecimal withdrawSum) {
 		this.amount = setAmount(amount);
 		this.pointType = pointType;
+		this.expireDate = expireDate;
 		setUserId(userId);
 		this.processDate = processDate;
 		this.depositSum = setAmount(depositSum);

--- a/src/main/java/com/sh/point/domain/point/PointDetailRepository.java
+++ b/src/main/java/com/sh/point/domain/point/PointDetailRepository.java
@@ -1,15 +1,22 @@
 package com.sh.point.domain.point;
 
-import java.time.LocalDateTime;
+import java.math.BigDecimal;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface PointDetailRepository extends JpaRepository<PointDetail, Long> {
 	Optional<PointDetail> findTopByUserIdOrderByIdDesc(String userId);
 
-	Optional<PointDetail> findTopByUserIdAndProcessDateBeforeOrderByProcessDateDesc(String userId,
-		LocalDateTime processDateMinusOneYear);
+	// 만료된 포인트의 총합 가져오기
+	@Query("""
+		    SELECT COALESCE(SUM(pd.amount), 0)
+		    FROM PointDetail pd
+		    WHERE pd.expireDate < NOW() AND pd.userId = :userId
+		""")
+	BigDecimal findExpiredPointSum(@Param("userId") String userId);
 }
 
 

--- a/src/main/java/com/sh/point/domain/point/PointType.java
+++ b/src/main/java/com/sh/point/domain/point/PointType.java
@@ -9,7 +9,6 @@ public enum PointType {
 	POINT_ACCUMULATE("적립", "포인트 적립"),
 	POINT_USE("사용", "포인트 사용"),
 	POINT_CANCEL("취소", "포인트 취소"),
-	POINT_EXPIRED("만료", "포인트 만료"),
 	;
 	private final String name;
 	private final String description;

--- a/src/test/java/com/sh/point/RepositoryTest.java
+++ b/src/test/java/com/sh/point/RepositoryTest.java
@@ -1,0 +1,15 @@
+package com.sh.point;
+
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+@EnableJpaAuditing
+@Transactional
+@ActiveProfiles("local")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@DataJpaTest
+public abstract class RepositoryTest {
+}

--- a/src/test/java/com/sh/point/domain/PointDetailRepositoryTest.java
+++ b/src/test/java/com/sh/point/domain/PointDetailRepositoryTest.java
@@ -4,25 +4,24 @@ import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.transaction.annotation.Transactional;
 
+import com.sh.point.RepositoryTest;
 import com.sh.point.domain.point.PointDetail;
 import com.sh.point.domain.point.PointDetailRepository;
 
-@Transactional
-@ActiveProfiles("local")
-@DataJpaTest
-class PointDetailRepositoryTest {
+class PointDetailRepositoryTest extends RepositoryTest {
+	private final String testUserId = "testUserId";
+
 	@Autowired
 	private PointDetailRepository pointDetailRepository;
 
 	@BeforeEach
 	void setUp() {
-		PointDetail initial = PointDetail.createInitial("123");
+		PointDetail initial = PointDetail.createInitial(testUserId);
 		PointDetail deposit1 = initial.deposit(BigDecimal.valueOf(200), LocalDateTime.of(1991, 4, 14, 11, 20, 10));
 		PointDetail deposit2 = initial.deposit(BigDecimal.valueOf(300), LocalDateTime.of(1991, 4, 14, 23, 20, 10));
 		PointDetail deposit3 = initial.deposit(BigDecimal.valueOf(300), LocalDateTime.of(1992, 4, 15, 23, 20, 10));
@@ -31,5 +30,12 @@ class PointDetailRepositoryTest {
 		pointDetailRepository.saveAllAndFlush(
 			List.of(deposit1, deposit2, deposit3, deposit4)
 		);
+	}
+
+	@Test
+	public void expireAmountTest() {
+		BigDecimal expiredPointSum = pointDetailRepository.findExpiredPointSum(testUserId);
+		Assertions.assertThat(expiredPointSum.stripTrailingZeros())
+			.isEqualTo(BigDecimal.valueOf(1100).stripTrailingZeros());
 	}
 }


### PR DESCRIPTION
## 📝 요약
- Expire Date 컬럼 추가

## 변경 내용
- 만료 컬럼을 따로 추가하여 포인트별 만료 날짜 개별 처리
- 기존 만료 포인트 조회 로직을 개선하여 `expire_date`를 기준으로 만료 여부를 확인하도록 변경

## 생각
- expireDate 가 지나지 않은 포인트들의 amount의 합을 이용하여 만료된 합을 처리하는 방식은 누적합 필드들을 두는 의미가 조금 퇴색 되는것 같다.
